### PR TITLE
Guard against the case where there are no active_titles in status

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,15 +151,17 @@ SmartglassDevice.prototype.get_power_state = function(callback)
             platform.restClient.getDeviceStatus(platform.liveid, function(status){
                 var currentId = 0;
 
-                for(var id in platform.apps){
-                    if(platform.apps[id].uri == status.active_titles[0].aum){
-                        currentId = id;
+                if (status.active_titles[0]) {
+                    for(var id in platform.apps){
+                        if(platform.apps[id].uri == status.active_titles[0].aum){
+                            currentId = id;
+                        }
                     }
-                }
-
-                if(currentId == 0){
-                    if(status.active_titles[0].aum.indexOf('.App') >= 0){
-                        currentId = 7;
+ 
+                    if(currentId == 0){
+                        if(status.active_titles[0].aum.indexOf('.App') >= 0){
+                            currentId = 7;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Observed a crash when the xbox was turned off manually and then Homekit attempted to refresh status. This should avoid it.